### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure API Gateway Throttling Limits

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -128,6 +128,8 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             "Endpoint",
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
+                throttling_burst_limit=100,
+                throttling_rate_limit=50,
                 access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
                 access_log_format=apigw_.AccessLogFormat.json_with_standard_fields(
                     caller=True,


### PR DESCRIPTION
## Summary

This PR implements API Gateway throttling configuration addressing AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes add explicit throttling limits to protect the API from unexpected traffic spikes, retry storms, and resource exhaustion.

## Changes Made

### API Gateway Throttling Configuration
- Added `throttling_burst_limit=100` for maximum concurrent requests
- Added `throttling_rate_limit=50` for requests per second
- Implements token bucket algorithm at API stage level as recommended by REL05-BP02

## Well-Architected Framework Compliance

These changes implement request throttling to mitigate resource exhaustion due to unexpected increases in demand. Without throttling, the API is vulnerable to traffic spikes that can exhaust resources and impact service availability.

✅ **Protection Against Traffic Spikes**: API can handle burst traffic up to 100 concurrent requests while maintaining steady-state rate of 50 requests/second
✅ **Token Bucket Implementation**: Uses API Gateway's native token bucket algorithm for efficient throttling
✅ **Graceful Degradation**: Returns 429 Too Many Requests when limits exceeded, allowing clients to implement retry logic
✅ **Resource Protection**: Prevents resource exhaustion from retry storms or unexpected demand increases

## Testing

After deployment:
1. Test normal API operations remain functional
2. Verify 429 responses are returned when throttle limits are exceeded
3. Monitor CloudWatch metrics for throttled requests
4. Consider load testing to validate limits match workload capacity

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added throttling configuration to API Gateway StageOptions

Fixes #6