### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure Lambda Reserved Concurrency

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -107,6 +107,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             ),
             memory_size=1024,
             timeout=Duration.minutes(5),
+            reserved_concurrent_executions=100,
             log_retention=logs.RetentionDays.ONE_YEAR,
             tracing=lambda_.Tracing.ACTIVE,
         )


### PR DESCRIPTION
## Summary

This PR implements Lambda reserved concurrency configuration addressing AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes prevent the Lambda function from consuming all available account-level concurrency, protecting other Lambda functions in the same account and region.

## Changes Made

### Lambda Concurrency Configuration
- Added `reserved_concurrent_executions=100` to limit maximum concurrent executions
- Prevents account-level concurrency exhaustion
- Aligns with recommended API Gateway throttling limits

## Well-Architected Framework Compliance

These changes implement concurrency controls to prevent resource exhaustion. Without reserved concurrency, this Lambda function could consume all available account concurrency during traffic spikes, impacting other workloads.

✅ **Account Protection**: Prevents this function from exhausting account-level Lambda concurrency quota
✅ **Predictable Performance**: Ensures consistent behavior under load with defined concurrency limits
✅ **Workload Isolation**: Protects other Lambda functions in the same account and region from resource starvation
✅ **Throttling Alignment**: Concurrency limit supports API Gateway burst capacity requirements

## Testing

After deployment:
1. Verify Lambda function deploys successfully with reserved concurrency
2. Monitor Lambda throttles metric in CloudWatch
3. Test that other Lambda functions in the account are not impacted during load
4. Validate concurrency limit is appropriate for expected traffic patterns

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added reserved_concurrent_executions to Lambda function configuration

Fixes #9