### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Implement Usage Plans and API Keys

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -70,20 +70,35 @@ $ cdk deploy --profile test
 ```
 
 ## After Deploy
-Navigate to AWS API Gateway console and test the API with below sample data 
-```json
-{
-    "year":"2023", 
-    "title":"kkkg",
-    "id":"12"
-}
+
+### Retrieve API Key
+After deployment, retrieve the API key value from AWS Systems Manager Parameter Store or API Gateway console:
+
+```bash
+aws apigateway get-api-keys --include-values --query "items[?name=='DemoApiKey'].value" --output text
 ```
 
-You should get below response 
+### Test the API
+Navigate to AWS API Gateway console or use curl to test the API. You must include the `x-api-key` header with your requests:
+
+```bash
+curl -X POST https://YOUR_API_ID.execute-api.REGION.amazonaws.com/prod/ \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"year":"2023", "title":"kkkg", "id":"12"}'
+```
+
+You should get below response:
 
 ```json
 {"message": "Successfully inserted data!"}
 ```
+
+### Usage Plan Limits
+The API is protected with the following limits per API key:
+- Rate limit: 10 requests per second
+- Burst limit: 20 concurrent requests
+- Daily quota: 10,000 requests
 
 ## Cleanup 
 Run below script to delete AWS resources created by this sample stack.

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -124,10 +124,13 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
         )
 
         # Create API Gateway
-        apigw_.LambdaRestApi(
+        api = apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
+            default_method_options=apigw_.MethodOptions(
+                api_key_required=True
+            ),
             deploy_options=apigw_.StageOptions(
                 throttling_burst_limit=100,
                 throttling_rate_limit=50,
@@ -145,4 +148,29 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
                 ),
                 tracing_enabled=True,
             ),
+        )
+
+        # Create usage plan
+        usage_plan = api.add_usage_plan(
+            "UsagePlan",
+            name="StandardUsagePlan",
+            throttle=apigw_.ThrottleSettings(
+                rate_limit=10,
+                burst_limit=20
+            ),
+            quota=apigw_.QuotaSettings(
+                limit=10000,
+                period=apigw_.Period.DAY
+            )
+        )
+
+        # Create API key
+        api_key = api.add_api_key("ApiKey", api_key_name="DemoApiKey")
+
+        # Associate API key with usage plan
+        usage_plan.add_api_key(api_key)
+
+        # Add API stage to usage plan
+        usage_plan.add_api_stage(
+            stage=api.deployment_stage
         )


### PR DESCRIPTION
## Summary

This PR implements usage plans and API keys for per-client throttling addressing AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes enable differentiation between API consumers and prevent a single client from exhausting resources.

## Changes Made

### Usage Plan Configuration
- Created usage plan with per-client throttling (rate_limit=10, burst_limit=20)
- Added daily quota limit of 10,000 requests per API key
- Implements token bucket algorithm on a per-client basis

### API Key Management
- Created API key "DemoApiKey" for client authentication
- Associated API key with usage plan
- Enabled API key requirement on all API methods

### Documentation Updates
- Updated README.md with API key retrieval instructions
- Added curl example showing x-api-key header usage
- Documented usage plan limits and quotas

## Well-Architected Framework Compliance

These changes implement per-client throttling to prevent individual consumers from exhausting API resources and impacting other users. Without usage plans, all clients share the same throttle limits.

✅ **Per-Client Rate Limiting**: Each API key has independent throttle limits (10 req/sec, 20 burst)
✅ **Quota Management**: Daily quota of 10,000 requests prevents sustained abuse
✅ **Consumer Isolation**: High-volume clients cannot impact other API consumers
✅ **Token Bucket Per Client**: Implements REL05-BP02 recommended per-client token bucket algorithm

## Testing

After deployment:
1. Retrieve API key using AWS CLI or console
2. Test API with x-api-key header
3. Verify 429 responses when per-client limits are exceeded
4. Confirm quota enforcement after daily limit reached
5. Test that requests without API key are rejected with 403

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added usage plan, API key, and method options configuration
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Added API key usage instructions and limits documentation

Fixes #7