### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Implement AWS WAF Rate Limiting

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -10,6 +10,7 @@ from aws_cdk import (
     aws_ec2 as ec2,
     aws_iam as iam,
     aws_logs as logs,
+    aws_wafv2 as wafv2,
     Duration,
 )
 from constructs import Construct
@@ -123,6 +124,39 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             retention=logs.RetentionDays.ONE_YEAR,
         )
 
+        # Create WAF Web ACL with rate-based rule
+        web_acl = wafv2.CfnWebACL(
+            self,
+            "ApiWebAcl",
+            default_action=wafv2.CfnWebACL.DefaultActionProperty(allow={}),
+            scope="REGIONAL",
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="ApiWebAclMetric",
+                sampled_requests_enabled=True
+            ),
+            rules=[
+                wafv2.CfnWebACL.RuleProperty(
+                    name="RateLimitRule",
+                    priority=1,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                            limit=2000,
+                            aggregate_key_type="IP"
+                        )
+                    ),
+                    action=wafv2.CfnWebACL.RuleActionProperty(
+                        block={}
+                    ),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="RateLimitRuleMetric",
+                        sampled_requests_enabled=True
+                    )
+                )
+            ]
+        )
+
         # Create API Gateway
         api = apigw_.LambdaRestApi(
             self,
@@ -173,4 +207,12 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
         # Add API stage to usage plan
         usage_plan.add_api_stage(
             stage=api.deployment_stage
+        )
+
+        # Associate WAF with API Gateway stage
+        wafv2.CfnWebACLAssociation(
+            self,
+            "WebAclAssociation",
+            resource_arn=f"arn:aws:apigateway:{self.region}::/restapis/{api.rest_api_id}/stages/{api.deployment_stage.stage_name}",
+            web_acl_arn=web_acl.attr_arn
         )


### PR DESCRIPTION
## Summary

This PR implements AWS WAF with rate-based rules addressing AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes protect the API Gateway endpoint from DDoS attacks, flooding, and malicious IP addresses through per-IP rate limiting.

## Changes Made

### AWS WAF Web ACL Configuration
- Created WAF Web ACL with rate-based rule limiting requests to 2000 per 5 minutes per IP address
- Configured aggregate key type as "IP" for per-IP address throttling
- Enabled CloudWatch metrics and sampled requests for monitoring

### API Gateway Integration
- Associated WAF Web ACL with API Gateway stage
- WAF protection applies to all API endpoints automatically

### Monitoring
- Enabled CloudWatch metrics for Web ACL (ApiWebAclMetric)
- Enabled CloudWatch metrics for rate limit rule (RateLimitRuleMetric)
- Enabled sampled requests for detailed analysis of blocked traffic

## Well-Architected Framework Compliance

These changes implement AWS WAF rate limiting to protect against floods and block malicious IPs as explicitly recommended by REL05-BP02. Without WAF, the API is vulnerable to DDoS attacks that can overwhelm resources.

✅ **DDoS Protection**: Blocks IPs exceeding 2000 requests per 5 minutes, preventing flooding attacks
✅ **Per-IP Rate Limiting**: Independent rate limits per source IP address prevent single-source attacks
✅ **Malicious IP Blocking**: Automatically blocks IPs exhibiting attack patterns
✅ **CloudWatch Integration**: Metrics enable monitoring and alerting on blocked requests

## Testing

After deployment:
1. Verify WAF Web ACL is created and associated with API Gateway
2. Monitor CloudWatch metrics for blocked requests
3. Test that legitimate traffic is not impacted
4. Simulate high-volume requests from single IP to verify rate limiting
5. Review sampled requests in WAF console for blocked traffic analysis

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added WAF Web ACL, rate-based rule, and Web ACL association

Fixes #8